### PR TITLE
Add Picute to Captions and Subtitles

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Please take a look at the [contribution guidelines](https://github.com/sitkevij/
 
 - [Aegisub](https://github.com/Aegisub/Aegisub) - Cross-platform advanced subtitle editor.
 - [ccextractor](https://github.com/CCExtractor/ccextractor) - Tool to extract closed captions from video streams.
+- [Picute](https://picute.net/en/tools/subtitle-encoding-converter) - Browser-based tool to repair garbled (mojibake) subtitle files by re-decoding legacy encodings (Shift-JIS, EUC-KR, GB18030, Big5) to UTF-8.
 - [suba](https://github.com/xy3/suba) - Automatically sync VTT or SRT subtitles with video.
 - [Subtitle Edit](https://github.com/SubtitleEdit/subtitleedit) - Free and open source editor for video subtitles.
 - [vtt.js](https://github.com/mozilla/vtt.js) - A JavaScript implementation of the WebVTT specification.


### PR DESCRIPTION
Adds **Picute** to **Captions and Subtitles** (alphabetised, after `ccextractor`).

It's a free, in-browser tool that repairs garbled (mojibake) subtitle files by re-decoding legacy encodings (Shift-JIS, EUC-KR, GB18030, Big5) to UTF-8 — a common problem when opening older `.srt`/`.ass` files for non-English media. Nothing is uploaded; everything runs locally in the browser.

Per the contribution guidelines:
- Sorted alphabetically, one link, link is the project name.
- Description is non-promotional, on the same line, ends with a period.

Disclosing affiliation per good practice: **I'm affiliated with this item** (built by Picute).
