### PR TITLE
Add Timeline Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Please take a look at the [contribution guidelines](https://github.com/sitkevij/
 - [SVT-AV1](https://github.com/OpenVisualCloud/SVT-AV1) - Scalable Video Technology AV1 encoder.
 - [SVT-HEVC](https://github.com/OpenVisualCloud/SVT-HEVC) - Scalable Video Technology HEVC encoder.
 - [SVT-VP9](https://github.com/OpenVisualCloud/SVT-VP9) - Scalable Video Technology VP9 encoder.
+- [Timeline Studio](https://github.com/MartinDelophy/ai-video-editor) - Local-first browser video editor with multi-track editing, AI voiceovers, automatic captions, and offline WebCodecs export.
 - [tomcast](https://georgi.unixsol.org/git/gfto/tomcast) - A simple http2multicast daemon designed to work 24/7.
 - [video-thumbnail-generator](https://github.com/flavioribeiro/video-thumbnail-generator) - Generate thumbnail sprites from videos.
 - [video-transcoding-api](https://github.com/NYTimes/video-transcoding-api) - Agnostic API to transcode media assets across different cloud services.


### PR DESCRIPTION
## What changed

Adds Timeline Studio to the Media Processing section.

Timeline Studio is a local-first browser video editor with multi-track editing, AI voiceovers, automatic captions, and offline WebCodecs export.

## Checks

- `npm run lint` passes.
- Link validation reports no invalid URLs.
- `lint_readme.sh` still reports the existing `FFmpeg` / `FastlyConvert` ordering issue already present on `master`; this PR does not change those entries.